### PR TITLE
Make ASC work with ASDF 3.1.7.x or later

### DIFF
--- a/dev/notes.text
+++ b/dev/notes.text
@@ -4,18 +4,15 @@
         (directory "user-home:darcs;asdf-systems;*.asd"))
 
 
-
 "user-home:darcs;asdf-systems;metabang.bind.asd"
 
-(compute-applicable-methods 
+(compute-applicable-methods
  #'asdf:operation-done-p
- (list (make-instance 'asdf:load-op) (asdf:find-system 'metabang.bind)))
+ (list (asdf:make-operation 'asdf:load-op) (asdf:find-system 'metabang.bind)))
 
 
 (asdf::component-name (asdf:find-system 'metabang.bind))
 (asdf::map-system-connections #'print)
 (asdf::map-system-connections #'inspect)
 
-(asdf::traverse (make-instance 'asdf:load-op)
-                (asdf::find-system 'bind-and-metatilities))
-
+(asdf::traverse :load-op 'bind-and-metatilities)


### PR DESCRIPTION
ASC
* fails to use make-operation, the official way of making an operation since 2.27, enforced for good in 3.1.7.x
* directly access `asdf::*defined*` and uses the value of `(system-registered-p x)`, both of which may be forbidden in the future.
* fails to use `:execute` in `eval-when`

This fixes these issues.

Note that the use of `if-let` means my patch assumes ASDF 2.27 or later. I don't suppose that's a problem, but I can make it compatible with 2012 ASDF 2.26 if you really want.