### PR TITLE
Load systems selectively by maintaining a *system-connections* table

### DIFF
--- a/dev/asdf-system-connections.lisp
+++ b/dev/asdf-system-connections.lisp
@@ -12,13 +12,49 @@
 
 ;;; ---------------------------------------------------------------------------
 
+(defun find-system-from-dep-spec (depends-on)
+  (etypecase depends-on
+    (system
+     depends-on)
+    ((or string symbol)
+     (find-system depends-on nil))
+    (list
+     (find-system
+      (let ((spec (ecase (first depends-on)
+                    (:version (second depends-on))
+                    (:feature (third depends-on)))))
+        (etypecase spec
+          ((or string symbol) spec)
+          (list
+           (ecase (first spec)
+             (:require (second spec))))))
+      nil))))
+
+(defun system-depends-on-p (system depends-on)
+  "Returns non-NIL if DEPENDS-ON is a dependency of SYSTEM."
+  (let* ((system (find-system-from-dep-spec system))
+         (depends-on (find-system-from-dep-spec depends-on))
+         (depends-on-name (when depends-on
+                            (component-name depends-on))))
+    (when (and system depends-on)
+      (some (lambda (dep)
+              (let* ((dep (find-system-from-dep-spec dep))
+                     (dep-name (component-name dep)))
+                (or (string= dep-name depends-on-name)
+                    (loop :for dep-dep :in (system-depends-on dep)
+                            :thereis (system-depends-on-p dep-dep depends-on)))))
+            (system-depends-on system)))))
+
+;;; ---------------------------------------------------------------------------
+
 (defvar *system-connections* (make-hash-table :test 'equal))
 
 (defmacro defsystem-connection (name &body options)
   (let ((requires (getf options :requires))
         (depends-on (getf options :depends-on))
         (class (getf options :class 'system-connection))
-        (connections (gensym "CONNECTIONS")))
+        (connections (gensym "CONNECTIONS"))
+        (prerequisites (gensym "PREREQUISITES")))
     (remf options :requires)
     (remf options :class)
     `(progn
@@ -35,32 +71,30 @@
                               (symbol (string-downcase (symbol-name s)))
                               (asdf:component (asdf:component-name s)))))
                      (let* ((r    (system-name r))
+                            (req  (gensym "REQ"))
                             (name (system-name name))
                             (requires
                               (sort (mapcar #'system-name requires) #'string<)))
-                       `(let ((,connections
-                                (append (gethash ',r *system-connections*)
-                                        (list (cons (remove ',r ',requires
-                                                            :test #'string=)
-                                                    ',name)))))
-                          (setf (gethash ',r *system-connections*)
-                                ,connections)))))
+                       `(let* ((,prerequisites
+                                 (remove-if
+                                  (lambda (,req)
+                                    (system-depends-on-p ,req ',r))
+                                  (remove ',r ',requires
+                                          :test #'string=)))
+                               (,connections
+                                 (append (gethash ',r *system-connections*)
+                                         (list (cons ,prerequisites
+                                                ',name)))))
+                          (when ,prerequisites
+                            (setf (gethash ',r *system-connections*)
+                                  ,connections))))))
                  requires)
        (values ',name))))
 
 ;;; ---------------------------------------------------------------------------
 
 (defun load-connected-systems (operation component)
-  (let* ((component (etypecase component
-                      (system
-                       component)
-                      ((or string symbol)
-                       (find-system component))
-                      (list
-                       (find-system
-                        (ecase (car component)
-                          (:version (second component))
-                          (:feature (third component)))))))
+  (let* ((component (find-system-from-dep-spec component))
          (deps (system-depends-on component))
          (connections (gethash (component-name component)
                                *system-connections*)))

--- a/dev/asdf-system-connections.lisp
+++ b/dev/asdf-system-connections.lisp
@@ -12,50 +12,68 @@
 
 ;;; ---------------------------------------------------------------------------
 
-(defun map-system-connections (fn)
-  (map-systems
-   (lambda (s) (when (typep s 'system-connection) (funcall fn s)))))
-
-;;; ---------------------------------------------------------------------------
+(defvar *system-connections* (make-hash-table :test 'equal))
 
 (defmacro defsystem-connection (name &body options)
   (let ((requires (getf options :requires))
-        (class (getf options :class 'system-connection)))
+        (depends-on (getf options :depends-on))
+        (class (getf options :class 'system-connection))
+        (connections (gensym "CONNECTIONS")))
     (remf options :requires)
     (remf options :class)
     `(progn
        (defsystem ,name
          :class ,class
-         :depends-on ,requires
+         :depends-on ,(append requires
+                              depends-on)
          :systems-required ,requires
          ,@options)
+       ,@(mapcar (lambda (r)
+                   (flet ((system-name (s)
+                            (etypecase s
+                              (string s)
+                              (symbol (string-downcase (symbol-name s)))
+                              (asdf:component (asdf:component-name s)))))
+                     (let* ((r    (system-name r))
+                            (name (system-name name))
+                            (requires
+                              (sort (mapcar #'system-name requires) #'string<)))
+                       `(let ((,connections
+                                (append (gethash ',r *system-connections*)
+                                        (list (cons (remove ',r ',requires
+                                                            :test #'string=)
+                                                    ',name)))))
+                          (setf (gethash ',r *system-connections*)
+                                ,connections)))))
+                 requires)
        (values ',name))))
 
 ;;; ---------------------------------------------------------------------------
 
-(defun load-connected-systems ()
-  (map-system-connections
-   (lambda (connection)
-     (when (and (required-systems-loaded-p connection)
-                (not (system-loaded-p (component-name connection))))
-       (load-system (component-name connection))))))
-
-(defun required-systems-loaded-p (connection)
-  (every #'system-loaded-p (systems-required connection)))
-
-;;; ---------------------------------------------------------------------------
-(unless (fboundp 'registered-system)
-  (defun registered-system (system-name)
-    (cdr (system-registered-p system-name))))
-
-(defun system-loaded-p (system-name)
-  (if-let (it (registered-system system-name))
-    (component-operation-time (make-operation 'load-op) it)))
+(defun load-connected-systems (operation component)
+  (let ((connections (gethash (typecase component
+                                (string component)
+                                (symbol (string-downcase (symbol-name component)))
+                                (asdf:component (asdf:component-name component)))
+                              *system-connections*)))
+    (loop :for (prerequisites . connection) :in connections
+          :do (when (and (not (component-loaded-p connection))
+                         (every #'component-loaded-p prerequisites))
+                (asdf:oos operation connection)))))
 
 ;;; ---------------------------------------------------------------------------
 
 (defmethod operate :after ((operation t) (component t) &key &allow-other-keys)
-  (load-connected-systems))
+  (when (or (eq 'asdf:load-op operation)
+            (typep operation 'asdf:load-op))
+    (loop :for dep :in (system-depends-on
+                        (etypecase component
+                          (system
+                           component)
+                          ((or string symbol)
+                           (find-system component))))
+          :do (load-connected-systems 'asdf:load-op dep))
+    (load-connected-systems 'asdf:load-op component)))
 
 ;;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes https://github.com/lisp-maintainers/asdf-system-connections/issues/3 and introduces two main changes:

- Allow `:requires` and `:depends-on` to differ from each other: this way, a connection system can now list another system or connection system as its dependency. Perhaps, this shouldn't actually be necessary.
- Load the connected systems only for the "concerned" system, and in a particular order